### PR TITLE
組み込みのWebViewの代わりにRNCommunityのWebViewを利用する

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "WebView",
     "HighCharts"
   ],
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*",
+    "react-native-webview": "*"
+  },
   "author": "Infinity0106",
   "license": "MIT",
   "bugs": {

--- a/react-native-highcharts.js
+++ b/react-native-highcharts.js
@@ -1,13 +1,10 @@
-import React, { Component, PropTypes, } from 'react';
+import React, { Component } from 'react';
 import {
-    AppRegistry,
     StyleSheet,
-    Text,
     View,
-    WebView,
-    Image,
     Dimensions
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 const win = Dimensions.get('window');
 class ChartWeb extends Component {
@@ -57,6 +54,8 @@ class ChartWeb extends Component {
                 width:win.width
             }
         }
+
+        this.reRenderWebView = this.reRenderWebView.bind(this);
     }
 
     // used to resize on orientation of display
@@ -87,6 +86,7 @@ class ChartWeb extends Component {
                   scalesPageToFit={true}
                   scrollEnabled={false}
                   automaticallyAdjustContentInsets={true}
+                  originWhitelist={['*']}
                   {...this.props}
               />
           </View>


### PR DESCRIPTION
- WebViewをRNCommunityのものに変更
- originWhitelist propを追加 (https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#basic-inline-html
- reRenderWebViewをbind

RN v0.63のプロジェクトで動作することを確認しました。

ただ、WebViewを変えたことによってNative/Dashboardのチャート上のonLongPressが機能しなくなっています。
とりあえずPRを出して次回onLongPressのバグ調査を行いたいと思います。